### PR TITLE
Add feature to zoom in/out ensuring exported image is not cropped as a result of it

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -366,6 +366,8 @@ const Canvas = () => {
         link.click();
         document.body.removeChild(link);
     };
+
+    // Handles exporting the canvas as an image removing empty space, that is, calculating the bounding box of all shapes
     const handleExportCanvas = () => {
         const stage = stageRef.current;
         const pixelRatio = 3;

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -402,6 +402,29 @@ const Canvas = () => {
         downloadDataURL(dataURL, 'canvas.png');
     };
 
+    // Draws a bounding rectangle around all shapes on the stage
+    const drawBoundingRectangle = (layer, contentBounds) => {
+        const rectX = contentBounds.minX;
+        const rectY = contentBounds.minY;
+        const rectWidth = contentBounds.maxX - contentBounds.minX;
+        const rectHeight = contentBounds.maxY - contentBounds.minY;
+
+        // Create a Konva Rect shape for the bounding rectangle
+        const rect = new Konva.Rect({
+            x: rectX,
+            y: rectY,
+            width: rectWidth,
+            height: rectHeight,
+            stroke: 'red',
+            strokeWidth: 4,
+        });
+
+        // Add the rectangle shape to the layer
+        layer.add(rect);
+        layer.batchDraw();
+        return rect;
+    }
+
     // Hides the ContextMenu when clicking outside of it
     useEffect(() => {
         const handleStageClick = () => {

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -517,7 +517,9 @@ const Canvas = () => {
                     onSelect={handleInstrumentSelect}
                 />
             )}
-            <Stage width={window.innerWidth} height={window.innerHeight} onClick={handleStageClick} ref={stageRef} draggable>
+
+            {/*Set stage width and height so it fits the viewport size when zooming out to 0.3 scale*/}
+            <Stage width={window.innerWidth/0.3} height={window.innerHeight/0.3} onClick={handleStageClick} ref={stageRef} draggable>
                 <Layer>
                     {/* Render CanvasLines... */}
                     {showLines && lines.map((line) => (

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -403,7 +403,14 @@ const Canvas = () => {
     };
 
     // Draws a bounding rectangle around all shapes on the stage
-    const drawBoundingRectangle = (layer, contentBounds) => {
+    const drawBoundingRectangle = (stage, layer, contentBounds) => {
+        // Adjust the content bounds to account for the stage position after dragging
+        contentBounds = {
+            minX: contentBounds.minX - stage.position().x,
+            minY: contentBounds.minY - stage.position().y,
+            maxX: contentBounds.maxX - stage.position().x,
+            maxY: contentBounds.maxY - stage.position().y,
+        }
         const rectX = contentBounds.minX;
         const rectY = contentBounds.minY;
         const rectWidth = contentBounds.maxX - contentBounds.minX;

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -450,6 +450,48 @@ const Canvas = () => {
         setShowLines(!showLines);
     };
 
+    // Add event listener to the stage to handle zooming
+    useEffect(() => {
+        const stage = stageRef.current.getStage();
+
+        const handleWheel = (e) => {
+            e.evt.preventDefault();
+
+            const oldScale = stage.scaleX();
+            const pointer = stage.getPointerPosition();
+
+            const mousePointTo = {
+                x: (pointer.x - stage.x()) / oldScale,
+                y: (pointer.y - stage.y()) / oldScale,
+            };
+
+            let direction = e.evt.deltaY > 0 ? 1 : -1;
+
+            if (e.evt.ctrlKey) {
+                direction = -direction;
+            }
+
+            // Calculate the new scale limiting it to a range of 0.3 to 2.6
+            const newScale = Math.max(0.3, Math.min(2.6, oldScale * (direction > 0 ? 1.1 : 1 / 1.1)));
+
+            stage.scale({ x: newScale, y: newScale });
+
+            const newPos = {
+                x: pointer.x - mousePointTo.x * newScale,
+                y: pointer.y - mousePointTo.y * newScale,
+            };
+            stage.position(newPos);
+
+            stage.batchDraw();
+        };
+
+        stage.on('wheel', handleWheel);
+
+        return () => {
+            stage.off('wheel', handleWheel);
+        };
+    }, []);
+
     return (
         <div>
             <HamburgerMenu onMenuItemClick={handleMenuItemClick} onExportCanvas={handleExportCanvas} />

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -359,10 +359,12 @@ const Canvas = () => {
     };
 
     const downloadDataURL = (dataURL, filename) => {
-        const anchor = document.createElement('a');
-        anchor.href = dataURL;
-        anchor.download = filename;
-        anchor.click();
+        const link = document.createElement('a');
+        link.href = dataURL;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
     };
     const handleExportCanvas = () => {
         const stage = stageRef.current;

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -322,12 +322,21 @@ const Canvas = () => {
             if (!(currentNode instanceof Konva.Line)) {
                 const nodePos = currentNode.getAbsolutePosition();
                 const nodeSize = currentNode.getSize();
+                let nodePosX = nodePos.x;
+                let nodePosY = nodePos.y;
+
+                // Rectangle-like shapes has origin at TOP LEFT (Rectangle, Sprite, Text, Image, etc), but Circles have
+                // their position at the center, so we need to adjust the coordinates
+                if (currentNode instanceof Konva.Circle) {
+                    nodePosX -= nodeSize.width / 2;
+                    nodePosY -= nodeSize.height / 2;
+                }
 
                 // Update min and max coordinates
-                minX = Math.min(minX, nodePos.x);
-                minY = Math.min(minY, nodePos.y);
-                maxX = Math.max(maxX, nodePos.x + nodeSize.width);
-                maxY = Math.max(maxY, nodePos.y + nodeSize.height);
+                minX = Math.min(minX, nodePosX);
+                minY = Math.min(minY, nodePosY);
+                maxX = Math.max(maxX, nodePosX + nodeSize.width);
+                maxY = Math.max(maxY, nodePosY + nodeSize.height);
 
                 // console.log('Node: ', currentNode)
                 // console.log('Node pos: ', nodePos)
@@ -345,6 +354,7 @@ const Canvas = () => {
             traverseChildren(childNode);
         });
 
+        console.log('Content bounds: ', { minX, minY, maxX, maxY })
         return { minX, minY, maxX, maxY };
     };
 


### PR DESCRIPTION
- Add feature to zoom in/out ensuring exported image is not cropped as a result of it, that is, all shapes are positioned in the viewport
- Fix bug when stage is dragged which changes the stage position and interferes with calculated bounding box used for image export